### PR TITLE
修复 tsconfig.json 中 @site 路径别名丢失的问题

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
-    "paths": {},
+    "paths": {
+      "@site/*": ["./*"]
+    },
     "jsx": "react-jsx",
   }
 }


### PR DESCRIPTION
## 概述
- `pnpm run typecheck`（`tsc`）报错：`Cannot find module '@site/src/service/system'`
- 该问题在 `refactor-001` 分支的基础提交上即可复现，与文档重构工作无关，属于预先存在的配置缺陷
- 根因：`tsconfig.json` 中本地 `paths` 被覆盖为空对象 `{}`，而 TypeScript 的 `paths` 不会与 `extends` 的基类配置合并，而是整体替换，导致 `@docusaurus/tsconfig` 基类里定义的 `"@site/*": ["./*"]` 映射被悄悄丢弃
- 修复方式：在本地 `paths` 中显式恢复 `"@site/*": ["./*"]` 映射，使其与 Docusaurus 自身 webpack 别名保持一致

## 测试计划
- [x] 运行 `pnpm run typecheck`（`tsc`），确认无报错，退出码为 0
- [x] 确认文件 `src/service/system.ts` 确实存在，模块路径本身没有问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)