### PR TITLE
🐛 修复移动端首页导航横向溢出

### DIFF
--- a/src/components/landing/LandingNav.tsx
+++ b/src/components/landing/LandingNav.tsx
@@ -96,11 +96,15 @@ function NavInstall() {
     >
       <Icon icon={store ? store.icon : "lucide:download"} />
       {store ? (
-        <Translate id="home.nav.installTo" values={{ browser: store.label }}>
-          {"安装到 {browser}"}
-        </Translate>
+        <span className={styles.lnavInstallLabel}>
+          <Translate id="home.nav.installTo" values={{ browser: store.label }}>
+            {"安装到 {browser}"}
+          </Translate>
+        </span>
       ) : (
-        <Translate id="home.nav.install">安装扩展</Translate>
+        <span className={styles.lnavInstallLabel}>
+          <Translate id="home.nav.install">安装扩展</Translate>
+        </span>
       )}
     </a>
   );

--- a/src/components/landing/landing.module.css
+++ b/src/components/landing/landing.module.css
@@ -376,9 +376,13 @@
     display: inline-flex;
   }
 }
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   .lnavInner {
     padding: 12px 16px;
+    gap: 12px;
+  }
+  .lnavActions {
+    gap: 8px;
   }
   .lnavInstall {
     min-width: 156px;
@@ -387,6 +391,47 @@
   }
   .lnavWord {
     font-size: 20px;
+  }
+}
+@media (max-width: 500px) {
+  .lnavInner {
+    padding: 12px;
+    gap: 8px;
+  }
+  .lnavActions {
+    gap: 6px;
+  }
+  .lnavInstall {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    padding: 0;
+  }
+  .lnavInstallLabel {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+@media (max-width: 360px) {
+  .lnavWord {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
   }
 }
 


### PR DESCRIPTION
## 修改说明

修复首页自定义导航栏在手机窄屏下宽度预算不足，导致页面出现横向滚动、右侧操作按钮超出屏幕的问题。

### 调整内容

- `≤640px` 收紧导航栏内边距和操作区间距
- `≤500px` 将安装按钮切换为 40px 图标按钮
- 安装按钮的翻译文案继续保留在无障碍树中
- `≤360px` 隐藏可见的 `ScriptCat` 文字，仅保留 Logo
- 保留主题切换、安装入口、菜单按钮和移动端展开面板
- 未使用全局 `overflow-x: hidden` 掩盖溢出

## 验证

修复前重新实测：

| 视口宽度 | 横向溢出 |
| ---: | ---: |
| 320px | 141px |
| 360px | 101px |
| 375px | 86px |
| 390px | 71px |
| 414px | 47px |
| 430px | 31px |

修复后：

- 320 / 360 / 375 / 390 / 414 / 430 / 552px 横向溢出均为 0
- 中英文页面均通过
- 移动菜单展开、关闭均通过
- 1440px 桌面端布局通过
- `pnpm build`
- `pnpm typecheck`
- `pnpm check`
- `git diff --check`
