### PR TITLE
fix(ui): improve light theme contrast for WCAG AA

### DIFF
--- a/src/components/landing/landing.module.css
+++ b/src/components/landing/landing.module.css
@@ -2156,7 +2156,7 @@
     transform: rotate(90deg);
   }
   :global([dir="rtl"]) .stepArrow {
-    transform: rotate(90deg);
+    transform: rotate(-90deg);
   }
 }
 

--- a/src/components/landing/landing.module.css
+++ b/src/components/landing/landing.module.css
@@ -14,7 +14,7 @@
   --lp-border: #e6edf4;
   --lp-ink: #0e2233;
   --lp-text: #3c4e60;
-  --lp-muted: #6e8194;
+  --lp-muted: #576d82;
   /* brand */
   --lp-brand: #1296db;
   --lp-brand-bright: #42b4f5;
@@ -22,9 +22,9 @@
   --lp-brand-soft: #dceffb;
   /* accents (stable across themes) */
   --lp-accent: #ff7a3d;
-  --lp-accent-deep: #f05e1c;
+  --lp-accent-deep: #c94a0d;
   --lp-accent-soft: #ffe7d6;
-  --lp-mint: #12b28c;
+  --lp-mint: #0b8264;
   --lp-mint-soft: #d8f3ec;
   --lp-violet: #6c5ce7;
   --lp-violet-soft: #e7e3fb;

--- a/src/components/landing/landing.module.css
+++ b/src/components/landing/landing.module.css
@@ -72,6 +72,7 @@
   --lp-brand-soft: #123249;
   --lp-accent-deep: #ff7a3d;
   --lp-accent-soft: #3a2517;
+  --lp-mint: #12b28c;
   --lp-mint-soft: #12312a;
   --lp-violet-soft: #221e3a;
   --lp-amber-soft: #322813;

--- a/src/components/landing/sections.tsx
+++ b/src/components/landing/sections.tsx
@@ -219,7 +219,7 @@ export function Scenarios() {
     {
       icon: "lucide:shield-check",
       bg: "var(--lp-accent-soft)",
-      color: "#F05E1C",
+      color: "#c94a0d",
       title: <Translate id="home.sc.adblock.t">去广告 · 净化</Translate>,
       desc: <Translate id="home.sc.adblock.d">屏蔽广告与弹窗，还网页一个清爽干净。</Translate>,
       link: <Translate id="home.sc.adblock.l">去广告脚本</Translate>,
@@ -228,7 +228,7 @@ export function Scenarios() {
     {
       icon: "lucide:shopping-cart",
       bg: "var(--lp-amber-soft)",
-      color: "#B9791A",
+      color: "#8c5c0f",
       title: <Translate id="home.sc.shop.t">网购 · 比价</Translate>,
       desc: <Translate id="home.sc.shop.d">全网比价、历史价格曲线、优惠券一键领。</Translate>,
       link: <Translate id="home.sc.shop.l">购物助手</Translate>,
@@ -237,7 +237,7 @@ export function Scenarios() {
     {
       icon: "lucide:wand-sparkles",
       bg: "var(--lp-mint-soft)",
-      color: "#0E8A6C",
+      color: "#0b8264",
       title: <Translate id="home.sc.auto.t">效率 · 自动化</Translate>,
       desc: <Translate id="home.sc.auto.d">自动签到、批量操作、贴心的快捷工具箱。</Translate>,
       link: <Translate id="home.sc.auto.l">效率脚本</Translate>,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -10,26 +10,26 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #4594d5;
-  --ifm-color-primary-dark: #2f87cf;
-  --ifm-color-primary-darker: #2c7fc4;
-  --ifm-color-primary-darkest: #2469a1;
-  --ifm-color-primary-light: #5ca1da;
-  --ifm-color-primary-lighter: #68a8dd;
-  --ifm-color-primary-lightest: #8abce5;
+  --ifm-color-primary: #1976d2;
+  --ifm-color-primary-dark: #1565b8;
+  --ifm-color-primary-darker: #125da8;
+  --ifm-color-primary-darkest: #0e4d8a;
+  --ifm-color-primary-light: #3d8fe0;
+  --ifm-color-primary-lighter: #4d97e3;
+  --ifm-color-primary-lightest: #6eb2ec;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme="dark"] {
-  --ifm-color-primary: #4594d5;
-  --ifm-color-primary-dark: #2f87cf;
-  --ifm-color-primary-darker: #2c7fc4;
-  --ifm-color-primary-darkest: #2469a1;
-  --ifm-color-primary-light: #5ca1da;
-  --ifm-color-primary-lighter: #68a8dd;
-  --ifm-color-primary-lightest: #8abce5;
+  --ifm-color-primary: #5cacf0;
+  --ifm-color-primary-dark: #41a0ec;
+  --ifm-color-primary-darker: #349bea;
+  --ifm-color-primary-darkest: #1b8be3;
+  --ifm-color-primary-light: #77b8f3;
+  --ifm-color-primary-lighter: #84bff5;
+  --ifm-color-primary-lightest: #a8d3f8;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
## Summary

- darken light-theme muted, accent, mint, amber, and primary colors so text and interactive elements meet WCAG AA contrast targets
- use a separate, lighter primary palette in dark mode to preserve readability
- keep mobile step arrows pointing downward in both LTR and RTL layouts

## Scope

This PR now contains only the UI changes specific to the contrast fix, rebased onto the latest `main` after #87 was merged. It modifies:

- `src/components/landing/landing.module.css`
- `src/components/landing/sections.tsx`
- `src/css/custom.css`

## Validation

- `pnpm run typecheck`
- `pnpm run build` — all 20 locales built successfully
- `pnpm run check` — URL inventory, fallback output, document/UI i18n parity, terminology structure, and frontmatter checks passed